### PR TITLE
Provide Apollo context to graphql server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist-tests/
 coverage/
 .nyc_output/
 
+.vscode
 .DS_Store
 npm-debug.log
 yarn-error.log

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "eslint-plugin-prettier": "2.6.2",
     "eslint-plugin-react": "7.10.0",
     "flow-bin": "^0.76.0",
-    "fusion-apollo": "^1.1.0",
+    "fusion-apollo": "^1.2.0-0",
     "fusion-core": "^1.4.1",
     "fusion-react-async": "^1.2.2",
     "fusion-test-utils": "^1.2.0",

--- a/src/server.js
+++ b/src/server.js
@@ -8,18 +8,23 @@
 
 import {createPlugin, type Middleware} from 'fusion-core';
 import {graphqlKoa} from 'apollo-server-koa';
-import {GraphQLSchemaToken} from 'fusion-apollo';
+import {GraphQLSchemaToken, ApolloContextToken} from 'fusion-apollo';
 import {ApolloServerEndpointToken} from './tokens';
 
 const plugin =
   __NODE__ &&
   createPlugin({
-    deps: {endpoint: ApolloServerEndpointToken, schema: GraphQLSchemaToken},
-    provides: ({schema}) =>
-      graphqlKoa(() => ({
+    deps: {
+      endpoint: ApolloServerEndpointToken,
+      schema: GraphQLSchemaToken,
+      context: ApolloContextToken.optional,
+    },
+    provides: ({schema, context}) =>
+      graphqlKoa(ctx => ({
         schema,
         tracing: true,
         cacheControl: true,
+        context: typeof context === 'function' ? context(ctx) : context,
       })),
     middleware: ({endpoint}, handler): Middleware => (ctx, next) =>
       ctx.path === endpoint ? handler(ctx) : next(),

--- a/src/server.js
+++ b/src/server.js
@@ -19,7 +19,7 @@ const plugin =
       schema: GraphQLSchemaToken,
       apolloContext: ApolloContextToken.optional,
     },
-    provides: ({schema, context}) =>
+    provides: ({schema, apolloContext}) =>
       graphqlKoa(ctx => ({
         schema,
         tracing: true,

--- a/src/server.js
+++ b/src/server.js
@@ -17,14 +17,14 @@ const plugin =
     deps: {
       endpoint: ApolloServerEndpointToken,
       schema: GraphQLSchemaToken,
-      context: ApolloContextToken.optional,
+      apolloContext: ApolloContextToken.optional,
     },
     provides: ({schema, context}) =>
       graphqlKoa(ctx => ({
         schema,
         tracing: true,
         cacheControl: true,
-        apolloContext: typeof context === 'function' ? context(ctx) : context,
+        context: typeof apolloContext === 'function' ? apolloContext(ctx) : apolloContext,
       })),
     middleware: ({endpoint}, handler): Middleware => (ctx, next) =>
       ctx.path === endpoint ? handler(ctx) : next(),

--- a/src/server.js
+++ b/src/server.js
@@ -24,7 +24,7 @@ const plugin =
         schema,
         tracing: true,
         cacheControl: true,
-        context: typeof context === 'function' ? context(ctx) : context,
+        apolloContext: typeof context === 'function' ? context(ctx) : context,
       })),
     middleware: ({endpoint}, handler): Middleware => (ctx, next) =>
       ctx.path === endpoint ? handler(ctx) : next(),

--- a/src/server.js
+++ b/src/server.js
@@ -24,7 +24,10 @@ const plugin =
         schema,
         tracing: true,
         cacheControl: true,
-        context: typeof apolloContext === 'function' ? apolloContext(ctx) : apolloContext,
+        context:
+          typeof apolloContext === 'function'
+            ? apolloContext(ctx)
+            : apolloContext,
       })),
     middleware: ({endpoint}, handler): Middleware => (ctx, next) =>
       ctx.path === endpoint ? handler(ctx) : next(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2680,11 +2680,11 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
 
-fusion-apollo@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/fusion-apollo/-/fusion-apollo-1.1.0.tgz#017c055697d36add22716aa78c5b9f50eb1d6279"
+fusion-apollo@^1.2.0-0:
+  version "1.2.0-0"
+  resolved "https://registry.yarnpkg.com/fusion-apollo/-/fusion-apollo-1.2.0-0.tgz#4ce3ff5624544e7775b32c3ea114ad2a3c06d851"
   dependencies:
-    fusion-react "^1.0.4"
+    fusion-react "^1.0.5"
 
 fusion-core@^1.2.2:
   version "1.4.0"
@@ -2716,7 +2716,7 @@ fusion-react-async@^1.2.2:
     prop-types "^15.5.8"
     react-is "^16.3.1"
 
-fusion-react@^1.0.4:
+fusion-react@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/fusion-react/-/fusion-react-1.0.5.tgz#478e5db3d49379d10ec9a072822a0e7b6092e036"
 


### PR DESCRIPTION
There currently isn't a way to configure the Apollo context (provided to resolvers).

This PR consumes the context token exported by `fusion-apollo` in https://github.com/fusionjs/fusion-apollo/pull/86, and passes the provided context to the Apollo Koa middleware.