### PR TITLE
Add a default for the graphql endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ import {makeExecutableSchema} from 'graphql-tools';
 export default () => {
   ...
   app.register(ApolloServer);
-  app.register(ApolloServerEndpointToken, '...');
+  app.register(ApolloServerEndpointToken, '/graphql');
   app.register(GraphQLSchemaToken, makeExecutableSchema(...));
   ...
 };

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ import {makeExecutableSchema} from 'graphql-tools';
 export default () => {
   ...
   app.register(ApolloServer);
-  app.register(ApolloServerEndpointToken, '/graphql');
+  app.register(ApolloServerEndpointToken, '/graphql'); // optional - /graphql is the default
   app.register(GraphQLSchemaToken, makeExecutableSchema(...));
   ...
 };

--- a/src/server.js
+++ b/src/server.js
@@ -17,7 +17,7 @@ import {GraphQLSchemaToken, ApolloContextToken} from 'fusion-apollo';
 import {ApolloServerEndpointToken} from './tokens';
 
 type ApolloServerDepsType = {
-  endpoint: typeof ApolloServerEndpointToken,
+  endpoint: typeof ApolloServerEndpointToken.optional,
   schema: typeof GraphQLSchemaToken,
   apolloContext: typeof ApolloContextToken.optional,
 };
@@ -29,7 +29,7 @@ type PluginType = FusionPlugin<ApolloServerDepsType, ApolloServerType>;
 const pluginFactory: () => PluginType = () =>
   createPlugin({
     deps: {
-      endpoint: ApolloServerEndpointToken,
+      endpoint: ApolloServerEndpointToken.optional,
       schema: GraphQLSchemaToken,
       apolloContext: ApolloContextToken.optional,
     },
@@ -43,7 +43,7 @@ const pluginFactory: () => PluginType = () =>
             ? apolloContext(ctx)
             : apolloContext,
       })),
-    middleware: ({endpoint}, handler): Middleware => (ctx, next) =>
+    middleware: ({endpoint = '/graphql'}, handler): Middleware => (ctx, next) =>
       ctx.path === endpoint ? handler(ctx) : next(),
   });
 


### PR DESCRIPTION
The standard is to just use the /graphql url, and it is rare to want to override this.