### PR TITLE
Set default apollo context to fusion ctx

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -33,7 +33,7 @@ const pluginFactory: () => PluginType = () =>
       schema: GraphQLSchemaToken,
       apolloContext: ApolloContextToken.optional,
     },
-    provides: ({schema, apolloContext}) =>
+    provides: ({schema, apolloContext = ctx => ctx}) =>
       graphqlKoa(ctx => ({
         schema,
         tracing: true,


### PR DESCRIPTION
This makes the most sense as a default as it allows you to use
request scoped plugins in resolvers.