### PR TITLE
Move the apollo handler call into the upstream

### DIFF
--- a/flow-typed/globals.js
+++ b/flow-typed/globals.js
@@ -1,4 +1,0 @@
-// @flow
-declare var __NODE__: boolean;
-declare var __BROWSER__: boolean;
-declare var __DEV__: boolean;

--- a/src/__tests__/server.node.js
+++ b/src/__tests__/server.node.js
@@ -49,7 +49,7 @@ tape('handler should serve queries on the specified endpoint', async t => {
 tape('Downstream Error handling should work', async t => {
   const app = new App('el', el => el);
   app.middleware((ctx, next) => {
-    ctx.throw('FAIL');
+    throw new Error('FAIL');
   });
   app.register(ApolloServer);
   app.register(ApolloServerEndpointToken, '/graphql');
@@ -74,7 +74,7 @@ tape('Upstream Error handling should work', async t => {
   app.register(ApolloServerEndpointToken, '/graphql');
   app.register(GraphQLSchemaToken, schema);
   app.middleware((ctx, next) => {
-    ctx.throw('FAIL');
+    throw new Error('FAIL');
   });
 
   const simulator = getSimulator(app);

--- a/src/__tests__/server.node.js
+++ b/src/__tests__/server.node.js
@@ -45,3 +45,47 @@ tape('handler should serve queries on the specified endpoint', async t => {
   t.equal(JSON.parse(String(ctx.body)).data.getHello.name, 'Hello World');
   t.end();
 });
+
+tape('Downstream Error handling should work', async t => {
+  const app = new App('el', el => el);
+  app.middleware((ctx, next) => {
+    ctx.throw('FAIL');
+  });
+  app.register(ApolloServer);
+  app.register(ApolloServerEndpointToken, '/graphql');
+  app.register(GraphQLSchemaToken, schema);
+
+  const simulator = getSimulator(app);
+  try {
+    await simulator.request('/graphql', {
+      body: query,
+      method: 'POST',
+    });
+    t.fail('Should not reach this');
+  } catch (e) {
+    t.ok(e, 'has error');
+    t.end();
+  }
+});
+
+tape('Upstream Error handling should work', async t => {
+  const app = new App('el', el => el);
+  app.register(ApolloServer);
+  app.register(ApolloServerEndpointToken, '/graphql');
+  app.register(GraphQLSchemaToken, schema);
+  app.middleware((ctx, next) => {
+    ctx.throw('FAIL');
+  });
+
+  const simulator = getSimulator(app);
+  try {
+    await simulator.request('/graphql', {
+      body: query,
+      method: 'POST',
+    });
+    t.fail('Should not reach this');
+  } catch (e) {
+    t.ok(e, 'has error');
+    t.end();
+  }
+});

--- a/src/server.js
+++ b/src/server.js
@@ -33,8 +33,8 @@ const pluginFactory: () => PluginType = () =>
       schema: GraphQLSchemaToken,
       apolloContext: ApolloContextToken.optional,
     },
-    provides: ({schema, apolloContext = ctx => ctx}) =>
-      graphqlKoa(ctx => ({
+    provides: ({schema, apolloContext = ctx => ctx}) => {
+      return graphqlKoa(ctx => ({
         schema,
         tracing: true,
         cacheControl: true,
@@ -43,9 +43,17 @@ const pluginFactory: () => PluginType = () =>
             ? // $FlowFixMe
               apolloContext(ctx)
             : apolloContext,
-      })),
-    middleware: ({endpoint = '/graphql'}, handler): Middleware => (ctx, next) =>
-      ctx.path === endpoint ? handler(ctx) : next(),
+      }));
+    },
+    middleware: ({endpoint = '/graphql'}, handler): Middleware => async (
+      ctx,
+      next
+    ) => {
+      await next();
+      if (ctx.path === endpoint) {
+        return handler(ctx);
+      }
+    },
   });
 
 export default ((__NODE__ && pluginFactory(): any): PluginType);


### PR DESCRIPTION
This ensures that next is always called, and helps with error handling.