### PR TITLE
Release v1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fusion-plugin-apollo-server",
   "description": "Connects a GraphQL schema to a Fusion.js server.",
-  "version": "1.2.0-4",
+  "version": "1.2.0",
   "license": "MIT",
   "repository": "fusionjs/fusion-plugin-apollo-server",
   "main": "./dist/index.js",


### PR DESCRIPTION
- Move the apollo handler call into the upstream ([#59](https://github.com/fusionjs/fusion-plugin-apollo-server/pull/59))
- Update dependencies ([#57](https://github.com/fusionjs/fusion-plugin-apollo-server/pull/57))
- Set default apollo context to fusion ctx ([#55](https://github.com/fusionjs/fusion-plugin-apollo-server/pull/55))
- Add a default for the graphql endpoint ([#54](https://github.com/fusionjs/fusion-plugin-apollo-server/pull/54))