### PR TITLE
Release v1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fusion-plugin-apollo-server",
   "description": "Connects a GraphQL schema to a Fusion.js server.",
-  "version": "1.3.0-0",
+  "version": "1.3.0",
   "license": "MIT",
   "repository": "fusionjs/fusion-plugin-apollo-server",
   "main": "./dist/index.js",


### PR DESCRIPTION
- Export format function token ([#68](https://github.com/fusionjs/fusion-plugin-apollo-server/pull/68))
- Add `formatError` option to plugin config ([#66](https://github.com/fusionjs/fusion-plugin-apollo-server/pull/66))